### PR TITLE
Pin event-model>=1.11.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ package:
 
 build:
   skip: True  # [py<36]
-  number: 0
+  number: 1
 
 requirements:
   host:
@@ -24,6 +24,7 @@ requirements:
     - dask
     - databroker >=0.13.3,<1.0
     - distributed
+    - event-model >=1.11.2
     - fabio
     - ffmpeg >=4.0  # [not win]
     - flake8


### PR DESCRIPTION
Using https://github.com/nsls-ii-forge/event-model-feedstock/pull/8.