### PR TITLE
Add bluesky 1.6.0 RC.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ package:
 
 build:
   skip: True  # [py<36]
-  number: 1
+  number: 0
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ requirements:
     - python
     - amostra <=1.0
     - attrs >=18.0
-    - bluesky <1.6.0rc
+    - bluesky >=1.6.0rc4
     - bluesky-kafka
     - dask
     - databroker <1.0.0a
@@ -92,7 +92,7 @@ test:
   commands:
     - python -V
     - ipython -V
-    - python -c "from distutils.version import LooseVersion; import bluesky; assert LooseVersion(bluesky.__version__) < '1.6'"
+    - python -c "from distutils.version import LooseVersion; import bluesky; assert LooseVersion(bluesky.__version__) >= '1.6'"
     - python -c "from distutils.version import LooseVersion; import databroker; assert LooseVersion(databroker.__version__) < '1.0'"
     - python -c "from distutils.version import LooseVersion; import ophyd; assert LooseVersion(ophyd.__version__) >= '1.4'"
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,7 +2,7 @@
 {% set year = "2020" %}
 {% set cycle = "1" %}
 {% set version = "0" %}
-{% set micro = "rc0" %}
+{% set micro = "rc1" %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
Bluesky 1.6.0rc4 has no known problems, so we are ready to add bluesky to the
set of things being acceptance-tested at these acceptance testing beamline
visits.

Ophyd 1.4.0rcX was already included.

DataBroker 1.0 is still intentionally *not* included because there are known
issues.