### PR TITLE
More analysis dependencies

### DIFF
--- a/recipe/check_results.py
+++ b/recipe/check_results.py
@@ -1,0 +1,70 @@
+import argparse
+# import os
+import sys
+import subprocess
+import logging
+
+
+logger = logging.getLogger(__name__)
+
+
+def check_conda_channels(forbidden_channel='conda-forge',
+                         cmd='conda list --show-channel-url'):
+    """Check conda channels.
+
+    This function checks if the list of channels does not have "forbidden"
+    channels (useful for validation of the resulted packages from a feedstock).
+
+    Parameters:
+    -----------
+    forbidden_channel: str, optional
+        a channel to warn about if it is found in the package list in a conda
+        environment
+    cmd: str, optional
+        a command to check a list of packages in a conda environment
+    """
+
+    # TODO: use later once https://github.com/conda/conda/pull/9998 resolved
+    # (either merged or instructions how to properly use the function provided)
+    # from conda.cli.main_list import list_packages
+    # pkgs = list_packages(os.environ['CONDA_PREFIX'], show_channel_urls=True)
+    # for p in pkgs[1]:
+    #     if 'conda-forge' in p:
+    #         print(p)
+
+    res = subprocess.run(cmd.split(), capture_output=True)
+    pkgs = res.stdout.decode().split('\n')
+
+    failed_packages = []
+    for p in pkgs:
+        if forbidden_channel in p:
+            failed_packages.append(p)
+
+    if failed_packages:
+        formatted = '\n'.join(failed_packages)
+        raise RuntimeError(f'Packages from the "{forbidden_channel}" channel '
+                           f'found:\n{formatted}')
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Check various parameters of a generated conda package.')
+    parser.add_argument('-f', '--forbidden-channel', dest='forbidden_channel',
+                        default='conda-forge',
+                        help=('a channel to warn about if it is found in the '
+                              'package list in a conda environment'))
+    parser.add_argument('-c', '--cmd', dest='cmd',
+                        default='conda list --show-channel-url',
+                        help=('a command to check a list of packages in a '
+                              'conda environment'))
+
+    args = parser.parse_args()
+
+    kwargs = {'forbidden_channel': args.forbidden_channel,
+              'cmd': args.cmd}
+
+    check_conda_channels(**kwargs)
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/recipe/check_results.py
+++ b/recipe/check_results.py
@@ -1,9 +1,11 @@
 import argparse
+import importlib
+import logging
+import subprocess
 # import os
 import sys
-import subprocess
-import logging
-
+from distutils.version import LooseVersion
+from subprocess import PIPE
 
 logger = logging.getLogger(__name__)
 
@@ -32,7 +34,7 @@ def check_conda_channels(forbidden_channel='conda-forge',
     #     if 'conda-forge' in p:
     #         print(p)
 
-    res = subprocess.run(cmd.split(), capture_output=True)
+    res = subprocess.run(cmd.split(), stdout=PIPE, stderr=PIPE)
     pkgs = res.stdout.decode().split('\n')
 
     failed_packages = []
@@ -44,26 +46,79 @@ def check_conda_channels(forbidden_channel='conda-forge',
         formatted = '\n'.join(failed_packages)
         raise RuntimeError(f'Packages from the "{forbidden_channel}" channel '
                            f'found:\n{formatted}')
+    else:
+        print(f'No packages were installed from {forbidden_channel}.')
+
+
+def check_package_version(package=None, expected_version=None):
+    """Check package version.
+
+    Parameters:
+    -----------
+    package: str
+        a package to check the version for
+    expected_version: str
+        minimum expected version of the package
+    """
+    if package is None:
+        raise ValueError(f'Wrong package name: {package}')
+    if expected_version is None:
+        raise ValueError(f'Wrong expected version: {expected_version}')
+
+    pkg = importlib.import_module(package)
+    pkg_version = pkg.__version__
+    if LooseVersion(pkg_version) < expected_version:
+        raise ValueError(f'The found version ("{pkg_version}") of "{package}" '
+                         f'is less than the expected version '
+                         f'({expected_version})')
+    else:
+        print(f'The found version ({pkg_version}) of "{package}" is more or '
+              f'equal the expected version ({expected_version})')
 
 
 def main():
     parser = argparse.ArgumentParser(
         description='Check various parameters of a generated conda package.')
+
+    types_of_check = ('channels', 'version')
+
+    # Type of the check
+    parser.add_argument('-t', '--check-type', dest='check_type',
+                        choices=types_of_check, default=None,
+                        help=(f'a type of check to perform. One of '
+                              f'{", ".join(types_of_check)}'))
+
+    # Check channels
     parser.add_argument('-f', '--forbidden-channel', dest='forbidden_channel',
-                        default='conda-forge',
+                        default='conda-forge', type=str,
                         help=('a channel to warn about if it is found in the '
                               'package list in a conda environment'))
     parser.add_argument('-c', '--cmd', dest='cmd',
-                        default='conda list --show-channel-url',
+                        default='conda list --show-channel-url', type=str,
                         help=('a command to check a list of packages in a '
                               'conda environment'))
 
+    # Check versions
+    parser.add_argument('-p', '--package', dest='package',
+                        default=None, type=str,
+                        help='a package to check the version for')
+    parser.add_argument('-e', '--expected-version', dest='expected_version',
+                        default=None, type=str,
+                        help='minimum expected version of the package')
+
     args = parser.parse_args()
 
-    kwargs = {'forbidden_channel': args.forbidden_channel,
-              'cmd': args.cmd}
+    if args.check_type is None:
+        parser.print_help()
 
-    check_conda_channels(**kwargs)
+    if args.check_type == 'channels':
+        channels_kwargs = {'forbidden_channel': args.forbidden_channel,
+                           'cmd': args.cmd}
+        check_conda_channels(**channels_kwargs)
+    elif args.check_type == 'version':
+        version_kwargs = {'package': args.package,
+                          'expected_version': args.expected_version}
+        check_package_version(**version_kwargs)
 
 
 if __name__ == '__main__':

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -121,6 +121,8 @@ test:
     - suitcase.utils
     - xray_vision
   commands:
+    # Fail if the "conda-forge" channel is in the list of channels.
+    - res=$(conda list --show-channel-url | grep "conda-forge"); if [ ! -z "$res" ]; then false; else true; fi  # [unix]
     - python -V
     - ipython -V
     - nexpy --help

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -122,7 +122,7 @@ test:
     - xray_vision
   commands:
     # Fail if the "conda-forge" channel is in the list of channels.
-    - res=$(conda list --show-channel-url | grep "conda-forge"); if [ ! -z "$res" ]; then false; else true; fi  # [unix]
+    - 'res=$(conda list --show-channel-url | grep "conda-forge"); if [ ! -z "$res" ]; then false; else true; fi'  # [unix]
     - python -V
     - ipython -V
     - nexpy --help

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ package:
 
 build:
   skip: True  # [py<36]
-  number: 0
+  number: 1
 
 requirements:
   host:
@@ -23,6 +23,7 @@ requirements:
     - black
     - bluesky >=1.6.0
     - bluesky-kafka
+    - boto3
     - dask
     - databroker >=1.0.0
     - distributed
@@ -32,33 +33,48 @@ requirements:
     - flake8
     - graphviz
     - grid-strategy
-    - h5py >=2.9.0
+    - h5py >=2.8.0
     - ipykernel
     - ipympl ==0.1.1
     - ipython
     - ipywidgets ==7.2.1
     - jupyter
     - jupyterlab
+    - line_profiler
     - lmfit
     - lxml
     - matplotlib >=3.1.0
+    - memory_profiler
+    - mendeleev
+    - modestimage
     - natsort
+    - netcdf4
     - nexpy
     - nodejs
+    - numexpr
     - numpy >=1.14.0
     - openpyxl
     - ophyd >=1.4.0
     - oscars
+    - papermill
     - peakutils
+    - periodictable
+    - pycentroids  # [not win]
     - pyepics >=3.4.2
+    - pyfai
     - pyfftw
     - pymongo >=3.7
     - pypdf2
     - pyqt >=5.9.0
+    - pystackreg
     - python-graphviz
-    - qt >=5.6.0
+    - pyxrf >=0.0.28
+    - pyzbar  # [not win]
+    - qt >=5.9.0
     - reportlab
+    - sasview
     - scikit-beam >=0.0.21
+    - scikit-learn
     - scipy
     - suitcase-csv
     - suitcase-json-metadata
@@ -70,10 +86,7 @@ requirements:
     - suitcase-utils
     - sympy
     - toml
-    # Comment out tomopy for now, need to figure out what's wrong with the
-    # recipe as it tries to get the dependency packages from conda-forge.
-    # See https://dev.azure.com/nsls2forge/nsls2forge/_build/results?buildId=2661&view=logs&j=4f922444-fdfe-5dcf-b824-02f86439ef14&t=937c195f-508d-5135-dc9f-d4b5730df0f7
-    # - tomopy >=1.7
+    - tomopy >=1.7.1  # [linux]
     - tornado
     - tqdm
     - tzlocal >=1.5

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -96,6 +96,8 @@ requirements:
     - xraylarch
 
 test:
+  files:
+    - check_results.py
   imports:
     - bluesky
     - dask
@@ -122,13 +124,14 @@ test:
     - xray_vision
   commands:
     # Fail if the "conda-forge" channel is in the list of channels.
-    - 'res=$(conda list --show-channel-url | grep "conda-forge"); if [ ! -z "$res" ]; then false; else true; fi'  # [unix]
+    - python check_results.py
     - python -V
     - ipython -V
     - nexpy --help
     - python -c "from distutils.version import LooseVersion; import bluesky; assert LooseVersion(bluesky.__version__) >= '1.6'"
     - python -c "from distutils.version import LooseVersion; import databroker; assert LooseVersion(databroker.__version__) >= '1.0'"
     - python -c "from distutils.version import LooseVersion; import ophyd; assert LooseVersion(ophyd.__version__) >= '1.4'"
+
 
 about:
   home: https://nsls-ii.github.io/deployment_docs.html

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -125,7 +125,8 @@ test:
     - xray_vision
   commands:
     # Fail if the "conda-forge" channel is in the list of channels.
-    - python check_results.py -t channels -f conda-forge
+    - python check_results.py -t channels -f conda-forge  # [not osx]
+    # Fail if versions of the packages are not as expected minimum ones.
     - python check_results.py -t version -p bluesky    -e 1.6
     - python check_results.py -t version -p ophyd      -e 1.4
     - python check_results.py -t version -p databroker -e 1.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,6 +38,7 @@ requirements:
     - ipympl ==0.1.1
     - ipython
     - ipywidgets ==7.2.1
+    - isort
     - jupyter
     - jupyterlab
     - line_profiler
@@ -124,14 +125,13 @@ test:
     - xray_vision
   commands:
     # Fail if the "conda-forge" channel is in the list of channels.
-    - python check_results.py
+    - python check_results.py -t channels -f conda-forge
+    - python check_results.py -t version -p bluesky    -e 1.6
+    - python check_results.py -t version -p ophyd      -e 1.4
+    - python check_results.py -t version -p databroker -e 1.0
     - python -V
     - ipython -V
     - nexpy --help
-    - python -c "from distutils.version import LooseVersion; import bluesky; assert LooseVersion(bluesky.__version__) >= '1.6'"
-    - python -c "from distutils.version import LooseVersion; import databroker; assert LooseVersion(databroker.__version__) >= '1.0'"
-    - python -c "from distutils.version import LooseVersion; import ophyd; assert LooseVersion(ophyd.__version__) >= '1.4'"
-
 
 about:
   home: https://nsls-ii.github.io/deployment_docs.html


### PR DESCRIPTION
All non-NSLS-II dependencies (i.e., no packages like `chxtools`, `csxtools`, ...).