### PR TITLE
analysis 2020-2.0 RC3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - attrs >=18.0
     - black
     - bluesky >=1.6.0
-    - bluesky-kafka
+    - bluesky-kafka  # [not win]
     - boto3
     - conda-pack
     - dask
@@ -73,7 +73,7 @@ requirements:
     - pymongo >=3.7
     - pypdf2
     - pyqt >=5.9.0
-    - pystackreg  # [not win]
+    - pystackreg
     - python-graphviz
     - pyxrf >=0.0.28
     - pyzbar  # [not win]
@@ -118,7 +118,7 @@ test:
     - ophyd
     - oscars
     - peakutils
-    - photutils  # [not win]
+    - photutils
     - pymongo
     - pyxrf
     - skbeam

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -73,7 +73,7 @@ requirements:
     - pymongo >=3.7
     - pypdf2
     - pyqt >=5.9.0
-    - pystackreg
+    - pystackreg  # [not win]
     - python-graphviz
     - pyxrf >=0.0.28
     - pyzbar  # [not win]
@@ -118,7 +118,7 @@ test:
     - ophyd
     - oscars
     - peakutils
-    - photutils
+    - photutils  # [not win]
     - pymongo
     - pyxrf
     - skbeam

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -65,6 +65,7 @@ requirements:
     - papermill
     - peakutils
     - periodictable
+    - photutils
     - pycentroids  # [not win]
     - pyepics >=3.4.2
     - pyfai

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ package:
 
 build:
   skip: True  # [py<36]
-  number: 4
+  number: 5
 
 requirements:
   host:
@@ -82,6 +82,7 @@ requirements:
     - scikit-beam >=0.0.21
     - scikit-learn
     - scipy
+    - srw  # [linux]
     - suitcase-csv
     - suitcase-json-metadata
     - suitcase-jsonl

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -118,9 +118,11 @@ test:
     - ophyd
     - oscars
     - peakutils
+    - photutils
     - pymongo
     - pyxrf
     - skbeam
+    - srwlpy
     - suitcase.csv
     - suitcase.json_metadata
     - suitcase.jsonl

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -122,7 +122,7 @@ test:
     - pymongo
     - pyxrf
     - skbeam
-    - srwlpy
+    - srwlpy  # [linux]
     - suitcase.csv
     - suitcase.json_metadata
     - suitcase.jsonl


### PR DESCRIPTION
Added `photutils` and `srw` to the list of distributed analysis packages.

Closes #21 #23.