### PR TITLE
2020 2.0rc7

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -8,12 +8,12 @@ jobs:
     vmImage: ubuntu-16.04
   strategy:
     matrix:
-      linux_python3.6:
-        CONFIG: linux_python3.6
+      linux_64_python3.6:
+        CONFIG: linux_64_python3.6
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: nsls2/nsls2forge:latest
-      linux_python3.7:
-        CONFIG: linux_python3.7
+      linux_64_python3.7:
+        CONFIG: linux_64_python3.7
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: nsls2/nsls2forge:latest
     maxParallel: 8

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -5,17 +5,15 @@
 jobs:
 - job: osx
   pool:
-    vmImage: macOS-10.14
+    vmImage: macOS-10.15
   strategy:
     matrix:
-      osx_python3.6:
-        CONFIG: osx_python3.6
+      osx_64_python3.6:
+        CONFIG: osx_64_python3.6
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: nsls2/nsls2forge:latest
-      osx_python3.7:
-        CONFIG: osx_python3.7
+      osx_64_python3.7:
+        CONFIG: osx_64_python3.7
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: nsls2/nsls2forge:latest
     maxParallel: 8
   timeoutInMinutes: 360
 

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -8,14 +8,12 @@ jobs:
     vmImage: vs2017-win2016
   strategy:
     matrix:
-      win_python3.6:
-        CONFIG: win_python3.6
+      win_64_python3.6:
+        CONFIG: win_64_python3.6
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: nsls2/nsls2forge:latest
-      win_python3.7:
-        CONFIG: win_python3.7
+      win_64_python3.7:
+        CONFIG: win_64_python3.7
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: nsls2/nsls2forge:latest
     maxParallel: 4
   timeoutInMinutes: 360
   variables:

--- a/.ci_support/linux_64_python3.6.yaml
+++ b/.ci_support/linux_64_python3.6.yaml
@@ -5,10 +5,12 @@ channel_targets:
 docker_image:
 - nsls2/nsls2forge:latest
 numpy:
-- '1.14'
+- '1.16'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- '3.7'
+- '3.6'
+target_platform:
+- linux-64

--- a/.ci_support/linux_64_python3.7.yaml
+++ b/.ci_support/linux_64_python3.7.yaml
@@ -1,20 +1,16 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
 channel_sources:
 - nsls2forge,defaults
 channel_targets:
 - nsls2forge main
 docker_image:
 - nsls2/nsls2forge:latest
-macos_machine:
-- x86_64-apple-darwin13.4.0
-macos_min_version:
-- '10.9'
 numpy:
-- '1.14'
+- '1.16'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- '3.6'
+- '3.7'
+target_platform:
+- linux-64

--- a/.ci_support/osx_64_python3.6.yaml
+++ b/.ci_support/osx_64_python3.6.yaml
@@ -1,14 +1,22 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
 channel_sources:
 - nsls2forge,defaults
 channel_targets:
 - nsls2forge main
 docker_image:
 - nsls2/nsls2forge:latest
+macos_machine:
+- x86_64-apple-darwin13.4.0
+macos_min_version:
+- '10.9'
 numpy:
-- '1.14'
+- '1.16'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- '3.7'
+- '3.6'
+target_platform:
+- osx-64

--- a/.ci_support/osx_64_python3.7.yaml
+++ b/.ci_support/osx_64_python3.7.yaml
@@ -11,10 +11,12 @@ macos_machine:
 macos_min_version:
 - '10.9'
 numpy:
-- '1.14'
+- '1.16'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
 - '3.7'
+target_platform:
+- osx-64

--- a/.ci_support/win_64_python3.6.yaml
+++ b/.ci_support/win_64_python3.6.yaml
@@ -5,10 +5,12 @@ channel_targets:
 docker_image:
 - nsls2/nsls2forge:latest
 numpy:
-- '1.14'
+- '1.16'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
 - '3.6'
+target_platform:
+- win-64

--- a/.ci_support/win_64_python3.7.yaml
+++ b/.ci_support/win_64_python3.7.yaml
@@ -5,10 +5,12 @@ channel_targets:
 docker_image:
 - nsls2/nsls2forge:latest
 numpy:
-- '1.14'
+- '1.16'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- '3.6'
+- '3.7'
+target_platform:
+- win-64

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -38,7 +38,7 @@ source run_conda_forge_build_setup
 make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
 conda build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
-    --suppress-variables \
+    --suppress-variables ${EXTRA_CB_OPTIONS:-} \
     --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
 
 if [[ "${UPLOAD_PACKAGES}" != "False" ]]; then

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -47,7 +47,8 @@ set -e
 
 echo -e "\n\nMaking the build clobber file and running the build."
 make_build_number ./ ./recipe ./.ci_support/${CONFIG}.yaml
-conda build ./recipe -m ./.ci_support/${CONFIG}.yaml --suppress-variables --clobber-file ./.ci_support/clobber_${CONFIG}.yaml
+
+conda build ./recipe -m ./.ci_support/${CONFIG}.yaml --suppress-variables --clobber-file ./.ci_support/clobber_${CONFIG}.yaml ${EXTRA_CB_OPTIONS:-}
 
 if [[ "${UPLOAD_PACKAGES}" != "False" ]]; then
   echo -e "\n\nUploading the packages."

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,5 @@
 BSD 3-clause license
-Copyright (c) 2015-2019, conda-forge
+Copyright (c) 2015-2020, conda-forge contributors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/README.md
+++ b/README.md
@@ -31,57 +31,51 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_python3.6</td>
+              <td>linux_64_python3.6</td>
               <td>
                 <a href="https://dev.azure.com/nsls2forge/nsls2forge/_build/latest?definitionId=71&branchName=master">
-                  <img src="https://dev.azure.com/nsls2forge/nsls2forge/_apis/build/status/analysis-feedstock?branchName=master&jobName=linux&configuration=linux_python3.6" alt="variant">
+                  <img src="https://dev.azure.com/nsls2forge/nsls2forge/_apis/build/status/analysis-feedstock?branchName=master&jobName=linux&configuration=linux_64_python3.6" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_python3.7</td>
+              <td>linux_64_python3.7</td>
               <td>
                 <a href="https://dev.azure.com/nsls2forge/nsls2forge/_build/latest?definitionId=71&branchName=master">
-                  <img src="https://dev.azure.com/nsls2forge/nsls2forge/_apis/build/status/analysis-feedstock?branchName=master&jobName=linux&configuration=linux_python3.7" alt="variant">
+                  <img src="https://dev.azure.com/nsls2forge/nsls2forge/_apis/build/status/analysis-feedstock?branchName=master&jobName=linux&configuration=linux_64_python3.7" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_python3.6</td>
+              <td>osx_64_python3.6</td>
               <td>
                 <a href="https://dev.azure.com/nsls2forge/nsls2forge/_build/latest?definitionId=71&branchName=master">
-                  <img src="https://dev.azure.com/nsls2forge/nsls2forge/_apis/build/status/analysis-feedstock?branchName=master&jobName=osx&configuration=osx_python3.6" alt="variant">
+                  <img src="https://dev.azure.com/nsls2forge/nsls2forge/_apis/build/status/analysis-feedstock?branchName=master&jobName=osx&configuration=osx_64_python3.6" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_python3.7</td>
+              <td>osx_64_python3.7</td>
               <td>
                 <a href="https://dev.azure.com/nsls2forge/nsls2forge/_build/latest?definitionId=71&branchName=master">
-                  <img src="https://dev.azure.com/nsls2forge/nsls2forge/_apis/build/status/analysis-feedstock?branchName=master&jobName=osx&configuration=osx_python3.7" alt="variant">
+                  <img src="https://dev.azure.com/nsls2forge/nsls2forge/_apis/build/status/analysis-feedstock?branchName=master&jobName=osx&configuration=osx_64_python3.7" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>win_python3.6</td>
+              <td>win_64_python3.6</td>
               <td>
                 <a href="https://dev.azure.com/nsls2forge/nsls2forge/_build/latest?definitionId=71&branchName=master">
-                  <img src="https://dev.azure.com/nsls2forge/nsls2forge/_apis/build/status/analysis-feedstock?branchName=master&jobName=win&configuration=win_python3.6" alt="variant">
+                  <img src="https://dev.azure.com/nsls2forge/nsls2forge/_apis/build/status/analysis-feedstock?branchName=master&jobName=win&configuration=win_64_python3.6" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>win_python3.7</td>
+              <td>win_64_python3.7</td>
               <td>
                 <a href="https://dev.azure.com/nsls2forge/nsls2forge/_build/latest?definitionId=71&branchName=master">
-                  <img src="https://dev.azure.com/nsls2forge/nsls2forge/_apis/build/status/analysis-feedstock?branchName=master&jobName=win&configuration=win_python3.7" alt="variant">
+                  <img src="https://dev.azure.com/nsls2forge/nsls2forge/_apis/build/status/analysis-feedstock?branchName=master&jobName=win&configuration=win_64_python3.7" alt="variant">
                 </a>
               </td>
             </tr>
           </tbody>
         </table>
       </details>
-    </td>
-  </tr>
-  <tr>
-    <td>Linux_ppc64le</td>
-    <td>
-      <img src="https://img.shields.io/badge/ppc64le-disabled-lightgrey.svg" alt="ppc64le disabled">
     </td>
   </tr>
 </table>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,5 +4,5 @@
 
 jobs:
   - template: ./.azure-pipelines/azure-pipelines-linux.yml
-  - template: ./.azure-pipelines/azure-pipelines-osx.yml
   - template: ./.azure-pipelines/azure-pipelines-win.yml
+  - template: ./.azure-pipelines/azure-pipelines-osx.yml

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ package:
 
 build:
   skip: True  # [py<36]
-  number: 8
+  number: 9
 
 requirements:
   host:
@@ -22,15 +22,15 @@ requirements:
     - arvpyf
     - attrs >=18.0
     - black
-    - bluesky >=1.6.0
+    - bluesky >=1.6.5
     - bluesky-kafka  # [not win]
     - boto3
     - conda-pack
     - dask
-    - databroker >=1.0.0
+    - databroker >=1.0.6
     - databroker-pack
     - distributed
-    - event-model >=1.15.1
+    - event-model >=1.15.2
     - fabio
     - ffmpeg >=4.0
     - flake8
@@ -57,11 +57,10 @@ requirements:
     - netcdf4
     - nexpy >=0.12.6
     - nodejs
-    - nsls2-detector-handlers >=0.0.2
     - numexpr
     - numpy >=1.14.0
     - openpyxl
-    - ophyd >=1.4.0
+    - ophyd >=1.5.2
     - oscars
     - papermill
     - peakutils
@@ -141,8 +140,8 @@ test:
     - check-results -t channels -f conda-forge  # [not osx]
     # Fail if versions of the packages are not as expected minimum ones.
     - check-results -t version -p bluesky    -e 1.6
-    - check-results -t version -p ophyd      -e 1.4
     - check-results -t version -p databroker -e 1.0
+    - check-results -t version -p ophyd      -e 1.5
     - python -V
     - ipython -V
     - nexpy --help


### PR DESCRIPTION
Needed to pin newer version of `bluesky`.
`nsls2-detector-handlers` moved to the `nsls2-analysis` metapackage to make this a more general package.