### PR TITLE
Fix redis

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ package:
 
 build:
   skip: True  # [py<36]
-  number: 12
+  number: 13
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -82,7 +82,7 @@ requirements:
     - pyxrf >=1.0.0
     - pyzbar  # [not win]
     - qt >=5.9.0
-    - redis
+    - redis-py
     - reportlab
     - requests
     - sasview
@@ -130,6 +130,7 @@ test:
     - photutils
     - pymongo
     - pyxrf
+    - redis
     - skbeam
     - srwlpy  # [linux]
     - srwpy


### PR DESCRIPTION
Close #34. Replace the package name `redis` by `redis-py` and add an import test.